### PR TITLE
feat: debug flag

### DIFF
--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -28,6 +28,10 @@ Then start the language server like so:
 some-sass-language-server --stdio
 ```
 
+**Options**
+
+`--debug` – runs the development build of the language server, helpful to get more context if the server crashes
+
 ### Workspace configuration
 
 The language server requests configuration via `workspace/configuration` on the `somesass` key. All fields are optional.

--- a/packages/language-server/bin/some-sass-language-server
+++ b/packages/language-server/bin/some-sass-language-server
@@ -1,3 +1,9 @@
 #!/usr/bin/env node
 const path = require("path");
-require(path.join(__dirname, "..", "dist", "node-server.js"));
+
+const args = process.argv.slice(2);
+if (args.includes("--debug")) {
+	require(path.join(__dirname, "..", "dist", "development", "node-server.js"));
+} else {
+	require(path.join(__dirname, "..", "dist", "node-server.js"));
+}

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -36,7 +36,7 @@ import type { FileSystemProvider } from "./file-system";
 import { getFileSystemProvider } from "./file-system-provider";
 import { RuntimeEnvironment } from "./runtime";
 import ScannerService from "./scanner";
-import type { ISettings } from "./settings";
+import { defaultSettings, IEditorSettings, type ISettings } from "./settings";
 import StorageService from "./storage";
 import { getSCSSRegionsDocument } from "./utils/embedded";
 
@@ -125,11 +125,23 @@ export class SomeSassServer {
 		);
 
 		this.connection.onInitialized(async () => {
-			const settings =
+			const somesassConfiguration: Partial<ISettings> =
 				await this.connection.workspace.getConfiguration("somesass");
-			const editorSettings =
+			const editorConfiguration: Partial<IEditorSettings> =
 				await this.connection.workspace.getConfiguration("editor");
 			const storageService = new StorageService();
+
+			const settings: ISettings = {
+				...defaultSettings,
+				...somesassConfiguration,
+			};
+
+			const editorSettings: IEditorSettings = {
+				insertSpaces: false,
+				indentSize: undefined,
+				tabSize: 2,
+				...editorConfiguration,
+			};
 
 			createContext({
 				clientCapabilities,


### PR DESCRIPTION
Add `--debug` flag to run the development build.

The development build can help give more context in case of a crash.

Also fixes a crash during initialize if there were no settings for `somesass`.