### PR TITLE
fix: avoid duplicate suggestions for CSS

### DIFF
--- a/packages/language-services/src/features/__tests__/find-document-links.test.ts
+++ b/packages/language-services/src/features/__tests__/find-document-links.test.ts
@@ -64,3 +64,21 @@ test("should return relative links", async () => {
 	const links = await ls.findDocumentLinks(document);
 	assert.strictEqual(links.length, 3, "expected to find three uses");
 });
+
+test("does not break on circular reference", async () => {
+	const ping = fileSystemProvider.createDocument(
+		['@use "./pong";', "$var: ping;"],
+		{ uri: "ping.scss" },
+	);
+	const pong = fileSystemProvider.createDocument(
+		['@use "./ping";', "$var: pong;"],
+		{ uri: "pong.scss" },
+	);
+
+	ls.parseStylesheet(ping);
+	ls.parseStylesheet(pong);
+
+	const links = await ls.findDocumentLinks(ping);
+
+	assert.strictEqual(links.length, 1, "expected to find link to pong");
+});

--- a/packages/language-services/src/features/do-complete.ts
+++ b/packages/language-services/src/features/do-complete.ts
@@ -315,24 +315,22 @@ export class DoComplete extends LanguageFeature {
 				}
 			}
 
-			if (result.items.length > 0) {
-				return result;
-			}
+			return result;
 
-			// If we don't have any suggestions, maybe upstream does
-			const upstreamResult = await upstreamLs.doComplete2(
-				document,
-				position,
-				stylesheet,
-				this.getDocumentContext(),
-				{
-					...this.configuration.completionSettings,
-					triggerPropertyValueCompletion:
-						this.configuration.completionSettings
-							?.triggerPropertyValueCompletion || false,
-				},
-			);
-			return upstreamResult;
+			// // If we don't have any suggestions, maybe upstream does
+			// const upstreamResult = await upstreamLs.doComplete2(
+			// 	document,
+			// 	position,
+			// 	stylesheet,
+			// 	this.getDocumentContext(),
+			// 	{
+			// 		...this.configuration.completionSettings,
+			// 		triggerPropertyValueCompletion:
+			// 			this.configuration.completionSettings
+			// 				?.triggerPropertyValueCompletion || false,
+			// 	},
+			// );
+			// return upstreamResult;
 		}
 
 		const upstreamResult = await upstreamLs.doComplete2(

--- a/vscode-extension/test/fixtures/completion/circular.scss
+++ b/vscode-extension/test/fixtures/completion/circular.scss
@@ -1,0 +1,3 @@
+@use "./main";
+
+$cicular: reference;

--- a/vscode-extension/test/fixtures/completion/main.scss
+++ b/vscode-extension/test/fixtures/completion/main.scss
@@ -35,3 +35,5 @@ $fonts: -apple-system;
 .foo {
   padding: math.fl
 }
+
+@use "./circular";

--- a/vscode-extension/test/fixtures/definition/circular.scss
+++ b/vscode-extension/test/fixtures/definition/circular.scss
@@ -1,0 +1,3 @@
+@use "./main";
+
+$cicular: reference;

--- a/vscode-extension/test/fixtures/definition/main.scss
+++ b/vscode-extension/test/fixtures/definition/main.scss
@@ -19,3 +19,5 @@
 .alert {
   @extend %alert;
 }
+
+@use "./circular";

--- a/vscode-extension/test/fixtures/diagnostics/circular.scss
+++ b/vscode-extension/test/fixtures/diagnostics/circular.scss
@@ -1,0 +1,3 @@
+@use "./main";
+
+$cicular: reference;

--- a/vscode-extension/test/fixtures/diagnostics/main.scss
+++ b/vscode-extension/test/fixtures/diagnostics/main.scss
@@ -1,4 +1,4 @@
-@use './helpers' as *;
+@use "./helpers" as *;
 
 /// @deprecated
 $_old-private-variable: 1px;
@@ -11,9 +11,11 @@ $_old-private-variable: 1px;
   content: $_old-private-variable;
 }
 
-@use '../namespace' as ns;
+@use "../namespace" as ns;
 
 .foo {
   color: ns.$deprecated;
   @include ns.mix-mix-ohno;
 }
+
+@use "./circular";

--- a/vscode-extension/test/fixtures/hover/circular.scss
+++ b/vscode-extension/test/fixtures/hover/circular.scss
@@ -1,0 +1,3 @@
+@use "./main";
+
+$cicular: reference;

--- a/vscode-extension/test/fixtures/hover/main.scss
+++ b/vscode-extension/test/fixtures/hover/main.scss
@@ -29,3 +29,5 @@ $documented-variable: "value";
 .alert {
   @extend %alert;
 }
+
+@use "./circular";

--- a/vscode-extension/test/fixtures/references/circular.scss
+++ b/vscode-extension/test/fixtures/references/circular.scss
@@ -1,0 +1,3 @@
+@use "./one";
+
+$cicular: reference;

--- a/vscode-extension/test/fixtures/references/one.scss
+++ b/vscode-extension/test/fixtures/references/one.scss
@@ -4,3 +4,5 @@
 	// Here it comes!
 	content: dev.fun-hello(dev.$fun-name);
 }
+
+@use "./circular";


### PR DESCRIPTION
Removes the fallback that calls vscode-css-languageservice. Duplicates aren't combined in the client.

Maybe this could be a setting in the future, in case folks want one language server to handle all the things.