### PR TITLE
fix: look up the editor limit for color decorators

### DIFF
--- a/packages/language-services/src/features/find-colors.ts
+++ b/packages/language-services/src/features/find-colors.ts
@@ -33,6 +33,14 @@ export class FindColors extends LanguageFeature {
 			return true;
 		});
 
+		if (
+			variables.length >
+			(this.configuration.editorSettings?.colorDecoratorsLimit || 500)
+		) {
+			// skip color decorators for large documents
+			return [];
+		}
+
 		for (const variable of variables) {
 			const value = await this.findValue(
 				document,

--- a/packages/language-services/src/language-feature.ts
+++ b/packages/language-services/src/language-feature.ts
@@ -348,6 +348,15 @@ export abstract class LanguageFeature {
 				if (!newDocument) {
 					return null;
 				}
+
+				if (newDocument.uri === document.uri) {
+					const definitionOffset = document.offsetAt(definition.range.start);
+					if (definitionOffset === variable.offset) {
+						// break early if we're looking up ourselves
+						return null;
+					}
+				}
+
 				return await this.internalFindValue(
 					newDocument,
 					definition.range.start,

--- a/packages/language-services/src/language-services-types.ts
+++ b/packages/language-services/src/language-services-types.ts
@@ -226,6 +226,11 @@ export interface EditorSettings {
 	 * An older editor setting in VS Code. If both this and {@link indentSize} is set, only `indentSize` will be used.
 	 */
 	tabSize?: number;
+	/**
+	 * Controls the max number of color decorators that can be rendered in an editor at once.
+	 * @default 500
+	 */
+	colorDecoratorsLimit?: number;
 }
 
 export interface AliasSettings {


### PR DESCRIPTION
Avoid getting stuck processing color decorators for large documents.

Fixes #164
