### PR TITLE
fix: regressions for namespaced completions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"prepare": "husky",
 		"postinstall": "patch-package",
 		"build": "nx run-many -t build",
-		"clean": "nx run-many -t clean",
+		"clean": "nx run-many -t clean && nx reset",
 		"coverage": "nx run-many -t coverage",
 		"dev": "echo Watching workspace for changes... && nx watch --all -- nx run \\$NX_PROJECT_NAME:build",
 		"lint": "eslint \"**/*.ts\" --cache",

--- a/packages/language-services/src/features/__tests__/do-complete-modules.test.ts
+++ b/packages/language-services/src/features/__tests__/do-complete-modules.test.ts
@@ -1001,9 +1001,12 @@ test("should suggest symbol from a different document via @use with wildcard ali
 		},
 	});
 
-	const one = fileSystemProvider.createDocument("$primary: limegreen;", {
-		uri: "one.scss",
-	});
+	const one = fileSystemProvider.createDocument(
+		["$primary: limegreen;", "@function one() { @return 1; }"],
+		{
+			uri: "one.scss",
+		},
+	);
 	const two = fileSystemProvider.createDocument(
 		['@use "./one" as *;', ".a { color: "],
 		{
@@ -1016,11 +1019,7 @@ test("should suggest symbol from a different document via @use with wildcard ali
 	ls.parseStylesheet(two);
 
 	const { items } = await ls.doComplete(two, Position.create(1, 12));
-	assert.notEqual(
-		0,
-		items.length,
-		"Expected to find a completion item for $primary",
-	);
+	assert.notEqual(2, items.length, "Expected to find two completion items");
 	assert.deepStrictEqual(
 		items.find((annotation) => annotation.label === "$primary"),
 		{
@@ -1030,6 +1029,26 @@ test("should suggest symbol from a different document via @use with wildcard ali
 			insertText: undefined,
 			kind: CompletionItemKind.Color,
 			label: "$primary",
+			sortText: undefined,
+			tags: [],
+		},
+	);
+	assert.deepStrictEqual(
+		items.find((annotation) => annotation.label === "one"),
+		{
+			documentation: {
+				kind: "markdown",
+				value:
+					"```scss\n@function one()\n```\n____\nFunction declared in one.scss",
+			},
+			filterText: "one",
+			insertText: "one()",
+			insertTextFormat: InsertTextFormat.Snippet,
+			kind: CompletionItemKind.Function,
+			label: "one",
+			labelDetails: {
+				detail: "()",
+			},
 			sortText: undefined,
 			tags: [],
 		},

--- a/packages/language-services/src/features/do-complete.ts
+++ b/packages/language-services/src/features/do-complete.ts
@@ -40,7 +40,7 @@ import { applySassDoc } from "../utils/sassdoc";
 const reNewSassdocBlock = /\/\/\/\s?$/;
 const reSassdocLine = /\/\/\/\s/;
 const reSassDotExt = /\.s(a|c)ss$/;
-const rePrivate = /^\$?[_].*$/;
+const rePrivate = /^\$?[-_].*$/;
 
 const reReturn = /^.*@return/;
 const reEach = /^.*@each .+ in /;

--- a/packages/language-services/src/features/do-complete.ts
+++ b/packages/language-services/src/features/do-complete.ts
@@ -949,16 +949,24 @@ export class DoComplete extends LanguageFeature {
 		const items: CompletionItem[] = [];
 
 		const label = `${prefix}${symbol.name}`;
-		const filterText = namespace
-			? `${namespace !== "*" ? namespace : ""}.${prefix}${symbol.name}`
-			: symbol.name;
+		let filterText = symbol.name;
+		if (namespace) {
+			if (namespace === "*") {
+				filterText = `${prefix}${symbol.name}`;
+			} else {
+				filterText = `${namespace}.${prefix}${symbol.name}`;
+			}
+		}
 
 		const isEmbedded = this.isEmbedded(initialDocument);
-		const insertText = namespace
-			? namespace !== "*" && !isEmbedded
-				? `.${prefix}${symbol.name}`
-				: `${prefix}${symbol.name}`
-			: symbol.name;
+		let insertText = symbol.name;
+		if (namespace) {
+			if (namespace === "*" || isEmbedded) {
+				insertText = `${prefix}${symbol.name}`;
+			} else {
+				insertText = `.${prefix}${symbol.name}`;
+			}
+		}
 
 		const sortText = isPrivate ? label.replace(/^$[_]/, "") : undefined;
 

--- a/packages/language-services/src/features/do-complete.ts
+++ b/packages/language-services/src/features/do-complete.ts
@@ -585,6 +585,7 @@ export class DoComplete extends LanguageFeature {
 		}
 
 		const links = await this.ls.findDocumentLinks(document);
+		let start: TextDocument | undefined = undefined;
 		for (const link of links) {
 			if (
 				link.target &&
@@ -603,19 +604,21 @@ export class DoComplete extends LanguageFeature {
 							return items;
 						}
 					}
+				} else {
+					start = this.cache.getDocument(link.target);
 				}
 				break;
 			}
 		}
 
-		if (items.length > 0) {
+		if (!start) {
 			return items;
 		}
 
 		const result = await this.findCompletionsInWorkspace(
 			document,
 			context,
-			document,
+			start,
 		);
 		return result;
 	}
@@ -721,6 +724,7 @@ export class DoComplete extends LanguageFeature {
 				return items;
 			},
 			start,
+			{ lazy: false, depth: 1 },
 		);
 		return result;
 	}

--- a/packages/language-services/src/language-feature.ts
+++ b/packages/language-services/src/language-feature.ts
@@ -34,6 +34,8 @@ type FindOptions = {
 	 * @default false
 	 */
 	lazy: boolean;
+	/** Set the initial starting depth, in case the caller uses a linked document as the starting point. */
+	depth?: number;
 };
 
 const defaultConfiguration: LanguageServiceConfiguration = {
@@ -138,7 +140,7 @@ export abstract class LanguageFeature {
 			show: string[],
 		) => T | T[] | undefined | Promise<T | T[] | undefined>,
 		initialDocument: TextDocument,
-		options: FindOptions = { lazy: false },
+		options: FindOptions = { lazy: false, depth: 0 },
 	): Promise<T[]> {
 		return this.internalFindInWorkspace(callback, initialDocument, options);
 	}
@@ -157,7 +159,7 @@ export abstract class LanguageFeature {
 		hide: string[] = [],
 		show: string[] = [],
 		visited = new Set<string>(),
-		depth = 0,
+		depth = options.depth || 0,
 	): Promise<T[]> {
 		if (visited.has(currentDocument.uri)) return [];
 


### PR DESCRIPTION
- Hides private symbols prefixed with `-`
- Fix a regression where all `@use`d modules would be suggested.
- Fix the filter text so functions get suggested if `@use`d with a wildcard alias.