### PR TITLE
fix: code completion bugs

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -271,6 +271,9 @@ export class SomeSassServer {
 			if (!document) return null;
 
 			const result = await ls.doComplete(document, params.position);
+			if (result.items.length === 0) {
+				result.isIncomplete = true;
+			}
 			return result;
 		});
 

--- a/packages/language-services/src/features/__tests__/do-complete-at-rules.test.ts
+++ b/packages/language-services/src/features/__tests__/do-complete-at-rules.test.ts
@@ -35,3 +35,78 @@ test("should suggest symbol from a different document via @use when in @return",
 	const { items } = await ls.doComplete(two, Position.create(1, 31));
 	assert.ok(items.find((annotation) => annotation.label === "$primary"));
 });
+
+test("should suggest symbol from a different document via @use when in @debug", async () => {
+	ls.configure({
+		completionSettings: {
+			suggestFromUseOnly: true,
+		},
+	});
+
+	const one = fileSystemProvider.createDocument("$primary: limegreen;", {
+		uri: "one.scss",
+	});
+	const two = fileSystemProvider.createDocument(
+		['@use "./one";', "@debug one."],
+		{
+			uri: "two.scss",
+		},
+	);
+
+	// emulate scanner of language service which adds workspace documents to the cache
+	ls.parseStylesheet(one);
+	ls.parseStylesheet(two);
+
+	const { items } = await ls.doComplete(two, Position.create(1, 11));
+	assert.ok(items.find((annotation) => annotation.label === "$primary"));
+});
+
+test("should suggest symbol from a different document via @use when in @warn", async () => {
+	ls.configure({
+		completionSettings: {
+			suggestFromUseOnly: true,
+		},
+	});
+
+	const one = fileSystemProvider.createDocument("$primary: limegreen;", {
+		uri: "one.scss",
+	});
+	const two = fileSystemProvider.createDocument(
+		['@use "./one";', "@warn one."],
+		{
+			uri: "two.scss",
+		},
+	);
+
+	// emulate scanner of language service which adds workspace documents to the cache
+	ls.parseStylesheet(one);
+	ls.parseStylesheet(two);
+
+	const { items } = await ls.doComplete(two, Position.create(1, 11));
+	assert.ok(items.find((annotation) => annotation.label === "$primary"));
+});
+
+test("should suggest symbol from a different document via @use when in @error", async () => {
+	ls.configure({
+		completionSettings: {
+			suggestFromUseOnly: true,
+		},
+	});
+
+	const one = fileSystemProvider.createDocument("$primary: limegreen;", {
+		uri: "one.scss",
+	});
+	const two = fileSystemProvider.createDocument(
+		['@use "./one";', "@error one."],
+		{
+			uri: "two.scss",
+		},
+	);
+
+	// emulate scanner of language service which adds workspace documents to the cache
+	ls.parseStylesheet(one);
+	ls.parseStylesheet(two);
+
+	const { items } = await ls.doComplete(two, Position.create(1, 11));
+	assert.ok(items.find((annotation) => annotation.label === "$primary"));
+});

--- a/packages/language-services/src/features/__tests__/do-complete-at-rules.test.ts
+++ b/packages/language-services/src/features/__tests__/do-complete-at-rules.test.ts
@@ -1,0 +1,37 @@
+import { test, assert, beforeEach } from "vitest";
+import { getLanguageService } from "../../language-services";
+import { Position } from "../../language-services-types";
+import { getOptions } from "../../utils/test-helpers";
+
+const { fileSystemProvider, ...rest } = getOptions();
+const ls = getLanguageService({ fileSystemProvider, ...rest });
+
+beforeEach(() => {
+	ls.clearCache();
+	ls.configure({}); // Reset any configuration to default
+});
+
+test("should suggest symbol from a different document via @use when in @return", async () => {
+	ls.configure({
+		completionSettings: {
+			suggestFromUseOnly: true,
+		},
+	});
+
+	const one = fileSystemProvider.createDocument("$primary: limegreen;", {
+		uri: "one.scss",
+	});
+	const two = fileSystemProvider.createDocument(
+		['@use "./one";', "@function test() { @return one."],
+		{
+			uri: "two.scss",
+		},
+	);
+
+	// emulate scanner of language service which adds workspace documents to the cache
+	ls.parseStylesheet(one);
+	ls.parseStylesheet(two);
+
+	const { items } = await ls.doComplete(two, Position.create(1, 31));
+	assert.ok(items.find((annotation) => annotation.label === "$primary"));
+});

--- a/packages/language-services/src/features/__tests__/do-complete-interpolation.test.ts
+++ b/packages/language-services/src/features/__tests__/do-complete-interpolation.test.ts
@@ -61,3 +61,28 @@ test("should suggest symbol from a different document via @use when in string in
 	const { items } = await ls.doComplete(two, Position.create(1, 29));
 	assert.ok(items.find((annotation) => annotation.label === "$primary"));
 });
+
+test("should suggest symbols when interpolation is part of CSS selector", async () => {
+	ls.configure({
+		completionSettings: {
+			suggestFromUseOnly: true,
+		},
+	});
+
+	const one = fileSystemProvider.createDocument("$selector: 'test';", {
+		uri: "one.scss",
+	});
+	const two = fileSystemProvider.createDocument(
+		['@use "./one";', ".#{one.} {}"],
+		{
+			uri: "two.scss",
+		},
+	);
+
+	// emulate scanner of language service which adds workspace documents to the cache
+	ls.parseStylesheet(one);
+	ls.parseStylesheet(two);
+
+	const { items } = await ls.doComplete(two, Position.create(1, 7));
+	assert.ok(items.find((annotation) => annotation.label === "$selector"));
+});

--- a/packages/language-services/src/features/__tests__/do-complete-interpolation.test.ts
+++ b/packages/language-services/src/features/__tests__/do-complete-interpolation.test.ts
@@ -1,0 +1,63 @@
+import { test, assert, beforeEach } from "vitest";
+import { getLanguageService } from "../../language-services";
+import { Position } from "../../language-services-types";
+import { getOptions } from "../../utils/test-helpers";
+
+const { fileSystemProvider, ...rest } = getOptions();
+const ls = getLanguageService({ fileSystemProvider, ...rest });
+
+beforeEach(() => {
+	ls.clearCache();
+	ls.configure({}); // Reset any configuration to default
+});
+
+test("should not suggest mixin or placeholder in string interpolation", async () => {
+	ls.configure({
+		completionSettings: {
+			suggestAllFromOpenDocument: true,
+			suggestFromUseOnly: false,
+		},
+	});
+
+	const one = fileSystemProvider.createDocument([
+		'$name: "value";',
+		"@mixin mixin($a: 1, $b) {}",
+		"@function compare($a: 1, $b) {}",
+		"%placeholder { color: blue; }",
+		'$interpolation: "/some/#{',
+	]);
+
+	ls.parseStylesheet(one);
+
+	const { items } = await ls.doComplete(one, Position.create(4, 25));
+
+	assert.ok(items.find((item) => item.label === "$name"));
+	assert.ok(items.find((item) => item.label === "compare"));
+	assert.isUndefined(items.find((item) => item.label === "mixin"));
+	assert.isUndefined(items.find((item) => item.label === "%placeholder"));
+});
+
+test("should suggest symbol from a different document via @use when in string interpolation", async () => {
+	ls.configure({
+		completionSettings: {
+			suggestFromUseOnly: true,
+		},
+	});
+
+	const one = fileSystemProvider.createDocument("$primary: limegreen;", {
+		uri: "one.scss",
+	});
+	const two = fileSystemProvider.createDocument(
+		['@use "./one";', '.a { background: url("/#{one.'],
+		{
+			uri: "two.scss",
+		},
+	);
+
+	// emulate scanner of language service which adds workspace documents to the cache
+	ls.parseStylesheet(one);
+	ls.parseStylesheet(two);
+
+	const { items } = await ls.doComplete(two, Position.create(1, 29));
+	assert.ok(items.find((annotation) => annotation.label === "$primary"));
+});

--- a/packages/language-services/src/features/__tests__/do-complete-modules.test.ts
+++ b/packages/language-services/src/features/__tests__/do-complete-modules.test.ts
@@ -84,56 +84,6 @@ test("should suggest symbol from a different document via @use", async () => {
 	);
 });
 
-test("should suggest symbol from a different document via @use when in string interpolation", async () => {
-	ls.configure({
-		completionSettings: {
-			suggestFromUseOnly: true,
-		},
-	});
-
-	const one = fileSystemProvider.createDocument("$primary: limegreen;", {
-		uri: "one.scss",
-	});
-	const two = fileSystemProvider.createDocument(
-		['@use "./one";', '.a { background: url("/#{one.'],
-		{
-			uri: "two.scss",
-		},
-	);
-
-	// emulate scanner of language service which adds workspace documents to the cache
-	ls.parseStylesheet(one);
-	ls.parseStylesheet(two);
-
-	const { items } = await ls.doComplete(two, Position.create(1, 29));
-	assert.ok(items.find((annotation) => annotation.label === "$primary"));
-});
-
-test("should suggest symbol from a different document via @use when in @return", async () => {
-	ls.configure({
-		completionSettings: {
-			suggestFromUseOnly: true,
-		},
-	});
-
-	const one = fileSystemProvider.createDocument("$primary: limegreen;", {
-		uri: "one.scss",
-	});
-	const two = fileSystemProvider.createDocument(
-		['@use "./one";', "@function test() { @return one."],
-		{
-			uri: "two.scss",
-		},
-	);
-
-	// emulate scanner of language service which adds workspace documents to the cache
-	ls.parseStylesheet(one);
-	ls.parseStylesheet(two);
-
-	const { items } = await ls.doComplete(two, Position.create(1, 31));
-	assert.ok(items.find((annotation) => annotation.label === "$primary"));
-});
-
 test("should not suggest symbols from a module used by the one we use", async () => {
 	ls.configure({
 		completionSettings: {

--- a/packages/language-services/src/features/__tests__/do-complete.test.ts
+++ b/packages/language-services/src/features/__tests__/do-complete.test.ts
@@ -115,32 +115,6 @@ test("should not suggest function, variable or mixin after an @extend", async ()
 	assert.isUndefined(items.find((item) => item.label === "compare"));
 });
 
-test("should not suggest mixin or placeholder in string interpolation", async () => {
-	ls.configure({
-		completionSettings: {
-			suggestAllFromOpenDocument: true,
-			suggestFromUseOnly: false,
-		},
-	});
-
-	const one = fileSystemProvider.createDocument([
-		'$name: "value";',
-		"@mixin mixin($a: 1, $b) {}",
-		"@function compare($a: 1, $b) {}",
-		"%placeholder { color: blue; }",
-		'$interpolation: "/some/#{',
-	]);
-
-	ls.parseStylesheet(one);
-
-	const { items } = await ls.doComplete(one, Position.create(4, 25));
-
-	assert.ok(items.find((item) => item.label === "$name"));
-	assert.ok(items.find((item) => item.label === "compare"));
-	assert.isUndefined(items.find((item) => item.label === "mixin"));
-	assert.isUndefined(items.find((item) => item.label === "%placeholder"));
-});
-
 test("should suggest variable in @return", async () => {
 	ls.configure({
 		completionSettings: {

--- a/packages/language-services/src/features/do-complete.ts
+++ b/packages/language-services/src/features/do-complete.ts
@@ -48,6 +48,9 @@ const reFor = /^.*@for .+ from /;
 const reIf = /^.*@if /;
 const reElseIf = /^.*@else if /;
 const reWhile = /^.*@while /;
+const reDebug = /^.*@debug /;
+const reWarn = /^.*@warn /;
+const reError = /^.*@error /;
 const rePropertyValue = /.*:\s*/;
 const reEmptyPropertyValue = /.*:\s*$/;
 const reQuotedValueInString = /["'](?:[^"'\\]|\\.)*["']/g;
@@ -420,12 +423,6 @@ export class DoComplete extends LanguageFeature {
 						currentWord.indexOf("."),
 					);
 
-		const isReturn = reReturn.test(lineBeforePosition);
-		const isIf = reIf.test(lineBeforePosition);
-		const isElseIf = reElseIf.test(lineBeforePosition);
-		const isEach = reEach.test(lineBeforePosition);
-		const isFor = reFor.test(lineBeforePosition);
-		const isWhile = reWhile.test(lineBeforePosition);
 		const isPropertyValue = rePropertyValue.test(lineBeforePosition);
 		const isEmptyValue = reEmptyPropertyValue.test(lineBeforePosition);
 		const isQuotes = reQuotes.test(
@@ -433,7 +430,15 @@ export class DoComplete extends LanguageFeature {
 		);
 
 		const isControlFlow =
-			isReturn || isIf || isElseIf || isEach || isFor || isWhile;
+			reReturn.test(lineBeforePosition) ||
+			reIf.test(lineBeforePosition) ||
+			reElseIf.test(lineBeforePosition) ||
+			reEach.test(lineBeforePosition) ||
+			reFor.test(lineBeforePosition) ||
+			reWhile.test(lineBeforePosition) ||
+			reDebug.test(lineBeforePosition) ||
+			reError.test(lineBeforePosition) ||
+			reWarn.test(lineBeforePosition);
 
 		if ((isControlFlow || isPropertyValue) && !isEmptyValue && !isQuotes) {
 			if (context.namespace && currentWord.endsWith(".")) {

--- a/packages/language-services/src/features/do-complete.ts
+++ b/packages/language-services/src/features/do-complete.ts
@@ -425,7 +425,7 @@ export class DoComplete extends LanguageFeature {
 				: currentWord.substring(
 						// Skip #{ if this is interpolation
 						isInterpolation ? currentWord.indexOf("{") + 1 : 0,
-						currentWord.indexOf("."),
+						currentWord.indexOf(".", currentWord.indexOf("{") + 1),
 					);
 
 		const isPropertyValue = rePropertyValue.test(lineBeforePosition);

--- a/packages/language-services/src/features/do-complete.ts
+++ b/packages/language-services/src/features/do-complete.ts
@@ -413,6 +413,11 @@ export class DoComplete extends LanguageFeature {
 			currentWord,
 		};
 
+		if (isInterpolation) {
+			context.isFunctionContext = true;
+			context.isVariableContext = true;
+		}
+
 		// Is namespace, e.g. `namespace.$var` or `@include namespace.mixin` or `namespace.func()`
 		context.namespace =
 			currentWord.length === 0 || !currentWord.includes(".")

--- a/packages/language-services/src/language-feature.ts
+++ b/packages/language-services/src/language-feature.ts
@@ -198,6 +198,14 @@ export abstract class LanguageFeature {
 		}
 
 		let result: T[] = [];
+
+		// gather the results from the initial document if any
+		if (Array.isArray(callbackResult)) {
+			result.push(...callbackResult);
+		} else if (callbackResult) {
+			result.push(callbackResult);
+		}
+
 		for (const link of links) {
 			if (!link.target || link.target === currentDocument.uri) {
 				continue;
@@ -244,7 +252,7 @@ export abstract class LanguageFeature {
 				visited,
 				depth + 1,
 			);
-			result = result.concat(linkResult);
+			result.push(...linkResult);
 		}
 
 		return result;


### PR DESCRIPTION
Fixes most issues mentioned in #186, and a bonus:

- Add completions after [`@warn`](https://sass-lang.com/documentation/at-rules/warn/), [`@error`](https://sass-lang.com/documentation/at-rules/error/) and [`@debug`](https://sass-lang.com/documentation/at-rules/debug/)
- Add completions when using interpolation as part of a class selector.
- Suggest symbols from the `@use` document also when it has `@forward` that include symbols.
