### PR TITLE
fix: suggest variables and symbols as parameters in string interpolation and mixin includes

### DIFF
--- a/packages/language-services/src/features/__tests__/do-complete.test.ts
+++ b/packages/language-services/src/features/__tests__/do-complete.test.ts
@@ -524,3 +524,29 @@ test("should suggest function in @for $i from 1 through ", async () => {
 	assert.isUndefined(items.find((item) => item.label === "mixin"));
 	assert.isUndefined(items.find((item) => item.label === "%placeholder"));
 });
+
+test("should suggest variable and function as parameter to mixin, not mixin or placeholder", async () => {
+	ls.configure({
+		completionSettings: {
+			suggestAllFromOpenDocument: true,
+			suggestFromUseOnly: false,
+		},
+	});
+
+	const one = fileSystemProvider.createDocument([
+		'$name: "value";',
+		"@mixin mixin($a: 1, $b) {}",
+		"@function compare($a: 1, $b) {}",
+		"%placeholder { color: blue; }",
+		".a { @include mixin(",
+	]);
+
+	ls.parseStylesheet(one);
+
+	const { items } = await ls.doComplete(one, Position.create(4, 20));
+
+	assert.ok(items.find((item) => item.label === "$name"));
+	assert.ok(items.find((item) => item.label === "compare"));
+	assert.isUndefined(items.find((item) => item.label === "mixin"));
+	assert.isUndefined(items.find((item) => item.label === "%placeholder"));
+});

--- a/packages/language-services/src/features/do-complete.ts
+++ b/packages/language-services/src/features/do-complete.ts
@@ -408,7 +408,8 @@ export class DoComplete extends LanguageFeature {
 			};
 		}
 
-		const isInterpolation = currentWord.includes("#{");
+		const isInterpolation =
+			currentWord.includes("#{") || lineBeforePosition.includes("#{");
 
 		const context: CompletionContext = {
 			currentWord,

--- a/packages/language-services/src/features/do-complete.ts
+++ b/packages/language-services/src/features/do-complete.ts
@@ -55,6 +55,7 @@ const rePropertyValue = /.*:\s*/;
 const reEmptyPropertyValue = /.*:\s*$/;
 const reQuotedValueInString = /["'](?:[^"'\\]|\\.)*["']/g;
 const reMixinReference = /.*@include\s+(.*)/;
+const reCompletedMixinWithParametersReference = /.*@include\s+(.*)\(/;
 const reComment = /^(.*\/\/|.*\/\*|\s*\*)/;
 const reSassDoc = /^[\\s]*\/{3}.*$/;
 const reQuotes = /["']/;
@@ -480,6 +481,11 @@ export class DoComplete extends LanguageFeature {
 
 		if (!isPropertyValue && reMixinReference.test(lineBeforePosition)) {
 			context.isMixinContext = true;
+			if (reCompletedMixinWithParametersReference.test(lineBeforePosition)) {
+				context.isMixinContext = false;
+				context.isVariableContext = true;
+				context.isFunctionContext = true;
+			}
 		}
 
 		return context;


### PR DESCRIPTION
The completion context didn't account for these cases. In the case of mixins, if the line had an `@include`, it would only suggest mixins. With this change you should see functions and variables pop up in this example.

```scss
@include test.hello(test.);
```

Similarly, the completion context didn't detect string interpolation properly when inside a parameter list for a function. After this change you should start seeing variables and function suggested in this example.

```scss
$test: #{test.selector(test.)};
```