### PR TITLE
fix: race condition in workspace scanner 

### DIFF
--- a/packages/language-server/src/workspace-scanner.ts
+++ b/packages/language-server/src/workspace-scanner.ts
@@ -53,22 +53,18 @@ export default class WorkspaceScanner {
 			uri = URI.parse(file.toString().replace("/static/extensions/fs", ""));
 		}
 
-		const alreadyParsed = this.#ls.hasCached(uri);
-		if (alreadyParsed) {
-			// The same file may be referenced by multiple other files,
-			// so skip doing the parsing work if it's already been done.
-			// Changes to the file are handled by the `update` method.
-			return;
-		}
-
 		try {
-			// TODO: figure out what caused the loop
-			const content = await this.#fs.readFile(uri);
+			let document: TextDocument | null | undefined =
+				this.#ls.getCachedTextDocument(uri);
+			if (!document) {
+				const content = await this.#fs.readFile(uri);
 
-			const document = getSCSSRegionsDocument(
-				TextDocument.create(uri.toString(), "scss", 1, content),
-			);
-			if (!document) return;
+				document = getSCSSRegionsDocument(
+					TextDocument.create(uri.toString(), "scss", 1, content),
+				);
+				if (!document) return;
+				this.#ls.parseStylesheet(document);
+			}
 
 			const links = await this.#ls.findDocumentLinks(document);
 			for (const link of links) {

--- a/packages/language-services/src/language-model-cache.ts
+++ b/packages/language-services/src/language-model-cache.ts
@@ -128,6 +128,10 @@ export class LanguageModelCache {
 		return Object.values(this.#languageModels).map((cached) => cached.document);
 	}
 
+	getCachedTextDocument(uri: string): TextDocument | undefined {
+		return this.#languageModels[uri]?.document;
+	}
+
 	has(uri: string) {
 		return typeof this.#languageModels[uri] !== "undefined";
 	}

--- a/packages/language-services/src/language-model-cache.ts
+++ b/packages/language-services/src/language-model-cache.ts
@@ -128,10 +128,6 @@ export class LanguageModelCache {
 		return Object.values(this.#languageModels).map((cached) => cached.document);
 	}
 
-	getCachedTextDocument(uri: string): TextDocument | undefined {
-		return this.#languageModels[uri]?.document;
-	}
-
 	has(uri: string) {
 		return typeof this.#languageModels[uri] !== "undefined";
 	}

--- a/packages/language-services/src/language-services-types.ts
+++ b/packages/language-services/src/language-services-types.ts
@@ -133,7 +133,7 @@ export interface LanguageService {
 		range: Range,
 		context?: CodeActionContext,
 	): Promise<CodeAction[]>;
-	hasCached(uri: URI): boolean;
+	getCachedTextDocument(uri: URI): TextDocument | undefined;
 	/**
 	 * Utility function to reparse an updated document.
 	 * Like {@link LanguageService.parseStylesheet}, but returns nothing.

--- a/packages/language-services/src/language-services.ts
+++ b/packages/language-services/src/language-services.ts
@@ -160,8 +160,8 @@ class LanguageServiceImpl implements LanguageService {
 		return this.#findSymbols.findWorkspaceSymbols(query);
 	}
 
-	hasCached(uri: URI): boolean {
-		return this.#cache.has(uri.toString());
+	getCachedTextDocument(uri: URI): TextDocument | undefined {
+		return this.#cache.getCachedTextDocument(uri.toString());
 	}
 
 	getColorPresentations(document: TextDocument, color: Color, range: Range) {

--- a/packages/language-services/src/language-services.ts
+++ b/packages/language-services/src/language-services.ts
@@ -161,7 +161,7 @@ class LanguageServiceImpl implements LanguageService {
 	}
 
 	getCachedTextDocument(uri: URI): TextDocument | undefined {
-		return this.#cache.getCachedTextDocument(uri.toString());
+		return this.#cache.getDocument(uri.toString());
 	}
 
 	getColorPresentations(document: TextDocument, color: Color, range: Range) {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -131,7 +131,7 @@
     "build": "webpack --mode development",
     "start:web": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=.",
     "lint": "eslint \"**/*.ts\" --cache",
-    "test:e2e": "node ./test/e2e/runTest.js",
+    "test:e2e": "node ./test/e2e/runTest.js && node ./test/new-e2e/runTest.js",
     "pretest:web": "webpack --config ./webpack.test-web.config.js ",
     "test:web": "node ./test/web/runTest.js"
   },


### PR DESCRIPTION
This time without the infinite loop for workspaces with circular references caused by https://github.com/wkillerud/some-sass/pull/205/commits/1d765a1e73ea3b3c093f1c3b2c6bbf1fc8235ff1