### PR TITLE
fix: remove extra dot for mixins and methods after modules in indented

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -130,6 +130,28 @@ export class SomeSassServer {
 			};
 		});
 
+		function applySettings(
+			editorSettings: IEditorSettings,
+			settings: ISettings,
+		) {
+			if (!ls) return;
+
+			ls.configure({
+				editorSettings,
+				workspaceRoot,
+				loadPaths: settings.loadPaths,
+				completionSettings: {
+					suggestAllFromOpenDocument: settings.suggestAllFromOpenDocument,
+					suggestFromUseOnly: settings.suggestFromUseOnly,
+					suggestionStyle: settings.suggestionStyle,
+					suggestFunctionsInStringContextAfterSymbols:
+						settings.suggestFunctionsInStringContextAfterSymbols,
+					afterModule: settings.completion?.afterModule,
+					beforeVariable: settings.completion?.beforeVariable,
+				},
+			});
+		}
+
 		this.connection.onInitialized(async () => {
 			this.connection.console.debug(
 				`[Server${process.pid ? `(${process.pid})` : ""} ${workspaceRoot}] <initialized> received`,
@@ -169,21 +191,7 @@ export class SomeSassServer {
 								);
 							}
 
-							ls.configure({
-								editorSettings,
-								workspaceRoot,
-								loadPaths: settings.loadPaths,
-								completionSettings: {
-									suggestAllFromOpenDocument:
-										settings.suggestAllFromOpenDocument,
-									suggestFromUseOnly: settings.suggestFromUseOnly,
-									suggestionStyle: settings.suggestionStyle,
-									suggestFunctionsInStringContextAfterSymbols:
-										settings.suggestFunctionsInStringContextAfterSymbols,
-									afterModule: settings.completion?.afterModule,
-									beforeVariable: settings.completion?.beforeVariable,
-								},
-							});
+							applySettings(editorSettings, settings);
 
 							this.connection.console.debug(
 								`[Server${process.pid ? `(${process.pid})` : ""} ${workspaceRoot}] <initialized> scanning workspace for files`,
@@ -275,20 +283,7 @@ export class SomeSassServer {
 				...editorConfiguration,
 			};
 
-			ls.configure({
-				editorSettings,
-				workspaceRoot,
-				loadPaths: settings.loadPaths,
-				completionSettings: {
-					suggestAllFromOpenDocument: settings.suggestAllFromOpenDocument,
-					suggestFromUseOnly: settings.suggestFromUseOnly,
-					suggestionStyle: settings.suggestionStyle,
-					suggestFunctionsInStringContextAfterSymbols:
-						settings.suggestFunctionsInStringContextAfterSymbols,
-					afterModule: settings.completion?.afterModule,
-					beforeVariable: settings.completion?.beforeVariable,
-				},
-			});
+			applySettings(editorSettings, settings);
 		});
 
 		this.connection.onDidChangeWatchedFiles(async (event) => {

--- a/packages/language-services/src/features/do-complete.ts
+++ b/packages/language-services/src/features/do-complete.ts
@@ -923,7 +923,7 @@ export class DoComplete extends LanguageFeature {
 		const noDot =
 			namespace === "*" ||
 			isEmbedded ||
-			initialDocument.languageId === ".sass" ||
+			initialDocument.languageId === "sass" ||
 			this.configuration.completionSettings?.afterModule === "";
 
 		const insertText = namespace
@@ -1056,7 +1056,7 @@ export class DoComplete extends LanguageFeature {
 		const noDot =
 			namespace === "*" ||
 			isEmbedded ||
-			initialDocument.languageId === ".sass" ||
+			initialDocument.languageId === "sass" ||
 			this.configuration.completionSettings?.afterModule === "";
 
 		const insertText = namespace
@@ -1155,7 +1155,7 @@ export class DoComplete extends LanguageFeature {
 
 			const noDot =
 				isEmbedded ||
-				document.languageId === ".sass" ||
+				document.languageId === "sass" ||
 				this.configuration.completionSettings?.afterModule === "";
 
 			const insertText = context.currentWord.includes(".")


### PR DESCRIPTION
`module..mixin` was a thing in indented, no more.