### PR TITLE
fix: use textEdit for completion items insertion

### DIFF
--- a/docs/src/language-server/configure-a-client.md
+++ b/docs/src/language-server/configure-a-client.md
@@ -24,29 +24,6 @@ For example, while we may document `"somesass.loadPaths": []` (and write it this
 }
 ```
 
-### Server-only settings
-
-In addition to [the user settings](../user-guide/settings.md), language clients may want to configure these server-only settings to tweak how certain features interact with your specific editor.
-
-| Key                                  | Description                                                                                                                                                                                                                                                                                |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `somesass.completion.afterModule`    | Set this to the empty string if you end up with `module..$variable` after accepting a code suggestion item. If `module.` or `module` disappears, you can set it to `"{module}."` or `"{module}"` respectively. That is a "magic string" that will be replaced with the actual module name. |
-| `somesass.completion.beforeVariable` | Set this to the empty string if you end up with `$$variable` after accepting a code suggestion item.                                                                                                                                                                                       |
-
-For example:
-
-```json
-{
-	"settings": {
-		"somesass": {
-			"completion": {
-				"afterModule": "{module}"
-			}
-		}
-	}
-}
-```
-
 ## Existing clients
 
 This list of [language client implementations][languageclients] may be a helpful starting point. You may also want to look at [existing clients](./existing-clients.md).

--- a/docs/src/language-server/helix.md
+++ b/docs/src/language-server/helix.md
@@ -8,7 +8,7 @@ You can configure new language servers in [`.config/helix/languages.toml`](https
 [language-server.some-sass-language-server]
 command = "some-sass-language-server"
 args = ["--stdio"]
-config = { somesass = { completion = { afterModule = "", beforeVariable = "" } } }
+config = { somesass = { loadPaths = [] } }
 
 [[language]]
 name = "scss"

--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -35,9 +35,7 @@ some-sass-language-server --stdio
 
 ### Workspace configuration
 
-The language server requests [settings](../user-guide/settings.md) via the [`workspace/configuration` message](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_configuration), on the `somesass` key. All fields are optional.
-
-See the [documentation for the available settings](https://wkillerud.github.io/some-sass/user-guide/settings.html).
+See [how to configure a client](https://wkillerud.github.io/some-sass/language-server/configure-a-client.html) and the [documentation for the available settings](https://wkillerud.github.io/some-sass/user-guide/settings.html).
 
 ## Capabilities
 

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -146,8 +146,6 @@ export class SomeSassServer {
 					suggestionStyle: settings.suggestionStyle,
 					suggestFunctionsInStringContextAfterSymbols:
 						settings.suggestFunctionsInStringContextAfterSymbols,
-					afterModule: settings.completion?.afterModule,
-					beforeVariable: settings.completion?.beforeVariable,
 				},
 			});
 		}

--- a/packages/language-server/src/settings.ts
+++ b/packages/language-server/src/settings.ts
@@ -8,10 +8,6 @@ export interface ISettings {
 	readonly suggestFromUseOnly: boolean;
 	readonly suggestFunctionsInStringContextAfterSymbols: " (+-*%";
 	readonly triggerPropertyValueCompletion: boolean;
-	readonly completion?: {
-		afterModule?: string;
-		beforeVariable?: string;
-	};
 }
 
 export interface IEditorSettings {

--- a/packages/language-services/src/features/__tests__/do-complete-embedded.test.ts
+++ b/packages/language-services/src/features/__tests__/do-complete-embedded.test.ts
@@ -96,7 +96,7 @@ test("should suggest symbol from a different document via @use", async () => {
 			'<style lang="scss">',
 			'@use "./one" as ns;',
 			".foo {",
-			"	color: ns.",
+			"	color: ns.;",
 			"}",
 			"</style>",
 		],
@@ -124,11 +124,23 @@ test("should suggest symbol from a different document via @use", async () => {
 			commitCharacters: [";", ","],
 			documentation: "limegreen\n____\nVariable declared in one.scss",
 			filterText: "ns.$primary",
-			insertText: "$primary",
 			kind: CompletionItemKind.Color,
 			label: "$primary",
 			sortText: undefined,
 			tags: [],
+			textEdit: {
+				newText: "ns.$primary",
+				range: {
+					end: {
+						character: 11,
+						line: 9,
+					},
+					start: {
+						character: 8,
+						line: 9,
+					},
+				},
+			},
 		},
 	);
 });

--- a/packages/language-services/src/features/__tests__/do-complete-modules.test.ts
+++ b/packages/language-services/src/features/__tests__/do-complete-modules.test.ts
@@ -41,12 +41,24 @@ test("suggests built-in sass modules", async () => {
 					"The value of the mathematical constant **π**.\n\n[Sass documentation](https://sass-lang.com/documentation/modules/math#$pi)",
 			},
 			filterText: "math.$pi",
-			insertText: ".$pi",
 			insertTextFormat: InsertTextFormat.PlainText,
 			kind: CompletionItemKind.Variable,
 			label: "$pi",
 			labelDetails: {
 				detail: undefined,
+			},
+			textEdit: {
+				newText: "math.$pi",
+				range: {
+					end: {
+						character: 11,
+						line: 1,
+					},
+					start: {
+						character: 6,
+						line: 1,
+					},
+				},
 			},
 		},
 	);
@@ -82,12 +94,24 @@ test("suggest sass built-ins that are forwarded by the stylesheet that is @used"
 					"The value of the mathematical constant **π**.\n\n[Sass documentation](https://sass-lang.com/documentation/modules/math#$pi)",
 			},
 			filterText: "test.$pi",
-			insertText: ".$pi",
 			insertTextFormat: InsertTextFormat.PlainText,
 			kind: CompletionItemKind.Variable,
 			label: "$pi",
 			labelDetails: {
 				detail: undefined,
+			},
+			textEdit: {
+				newText: "test.$pi",
+				range: {
+					end: {
+						character: 11,
+						line: 1,
+					},
+					start: {
+						character: 6,
+						line: 1,
+					},
+				},
 			},
 		},
 	);
@@ -102,7 +126,7 @@ test("suggest sass built-ins that are forwarded with a prefix", async () => {
 	);
 	const two = fileSystemProvider.createDocument([
 		'@use "./test";',
-		"$var: test.",
+		"$var: test.;",
 	]);
 
 	// emulate scanner of language service which adds workspace documents to the cache
@@ -126,12 +150,24 @@ test("suggest sass built-ins that are forwarded with a prefix", async () => {
 					"The value of the mathematical constant **π**.\n\n[Sass documentation](https://sass-lang.com/documentation/modules/math#$pi)",
 			},
 			filterText: "test.$math-pi",
-			insertText: ".$math-pi",
 			insertTextFormat: InsertTextFormat.PlainText,
 			kind: CompletionItemKind.Variable,
 			label: "$math-pi",
 			labelDetails: {
 				detail: undefined,
+			},
+			textEdit: {
+				newText: "test.$math-pi",
+				range: {
+					end: {
+						character: 11,
+						line: 1,
+					},
+					start: {
+						character: 6,
+						line: 1,
+					},
+				},
 			},
 		},
 	);
@@ -165,11 +201,23 @@ test("should suggest symbol from a different document via @use", async () => {
 			commitCharacters: [";", ","],
 			documentation: "limegreen\n____\nVariable declared in one.scss",
 			filterText: "one.$primary",
-			insertText: ".$primary",
 			kind: CompletionItemKind.Color,
 			label: "$primary",
 			sortText: undefined,
 			tags: [],
+			textEdit: {
+				newText: "one.$primary",
+				range: {
+					end: {
+						character: 16,
+						line: 1,
+					},
+					start: {
+						character: 12,
+						line: 1,
+					},
+				},
+			},
 		},
 	);
 });
@@ -208,11 +256,23 @@ test("should suggest symbols from the document we use when it also forwards anot
 			commitCharacters: [";", ","],
 			documentation: "red\n____\nVariable declared in two.scss",
 			filterText: "two.$secondary",
-			insertText: ".$secondary",
 			kind: CompletionItemKind.Color,
 			label: "$secondary",
 			sortText: undefined,
 			tags: [],
+			textEdit: {
+				newText: "two.$secondary",
+				range: {
+					end: {
+						character: 16,
+						line: 1,
+					},
+					start: {
+						character: 12,
+						line: 1,
+					},
+				},
+			},
 		},
 	);
 	assert.deepStrictEqual(
@@ -221,11 +281,23 @@ test("should suggest symbols from the document we use when it also forwards anot
 			commitCharacters: [";", ","],
 			documentation: "limegreen\n____\nVariable declared in one.scss",
 			filterText: "two.$primary",
-			insertText: ".$primary",
 			kind: CompletionItemKind.Color,
 			label: "$primary",
 			sortText: undefined,
 			tags: [],
+			textEdit: {
+				newText: "two.$primary",
+				range: {
+					end: {
+						character: 16,
+						line: 1,
+					},
+					start: {
+						character: 12,
+						line: 1,
+					},
+				},
+			},
 		},
 	);
 });
@@ -459,7 +531,7 @@ test("should suggest prefixed symbol from a different document via @use and @for
 		uri: "two.scss",
 	});
 	const three = fileSystemProvider.createDocument(
-		['@use "./two";', ".a { color: two."],
+		['@use "./two";', ".a { color: two.; }"],
 		{
 			uri: "three.scss",
 		},
@@ -482,11 +554,23 @@ test("should suggest prefixed symbol from a different document via @use and @for
 			commitCharacters: [";", ","],
 			documentation: "limegreen\n____\nVariable declared in one.scss",
 			filterText: "two.$foo-primary",
-			insertText: ".$foo-primary",
 			kind: CompletionItemKind.Color,
 			label: "$foo-primary",
 			sortText: undefined,
 			tags: [],
+			textEdit: {
+				newText: "two.$foo-primary",
+				range: {
+					end: {
+						character: 16,
+						line: 1,
+					},
+					start: {
+						character: 12,
+						line: 1,
+					},
+				},
+			},
 		},
 	);
 });
@@ -634,13 +718,25 @@ test("should suggest mixin with no parameter", async () => {
 					"```scss\n@mixin primary()\n```\n____\nMixin declared in one.scss",
 			},
 			filterText: "one.primary",
-			insertText: ".primary",
 			insertTextFormat: InsertTextFormat.Snippet,
 			kind: CompletionItemKind.Method,
 			label: "primary",
 			labelDetails: undefined,
 			sortText: undefined,
 			tags: [],
+			textEdit: {
+				newText: "one.primary",
+				range: {
+					end: {
+						character: 18,
+						line: 1,
+					},
+					start: {
+						character: 14,
+						line: 1,
+					},
+				},
+			},
 		},
 	);
 });
@@ -649,6 +745,7 @@ test("should suggest mixin with optional parameter", async () => {
 	ls.configure({
 		completionSettings: {
 			suggestFromUseOnly: true,
+			suggestionStyle: "nobracket",
 		},
 	});
 
@@ -676,28 +773,25 @@ test("should suggest mixin with optional parameter", async () => {
 						"```scss\n@mixin primary($color: red)\n```\n____\nMixin declared in one.scss",
 				},
 				filterText: "one.primary",
-				insertText: ".primary(${1:color})",
 				insertTextFormat: InsertTextFormat.Snippet,
 				kind: CompletionItemKind.Method,
 				label: "primary",
 				labelDetails: { detail: "($color: red)" },
 				sortText: undefined,
 				tags: [],
-			},
-			{
-				documentation: {
-					kind: "markdown",
-					value:
-						"```scss\n@mixin primary($color: red)\n```\n____\nMixin declared in one.scss",
+				textEdit: {
+					newText: "one.primary(${1:color})",
+					range: {
+						end: {
+							character: 18,
+							line: 1,
+						},
+						start: {
+							character: 14,
+							line: 1,
+						},
+					},
 				},
-				filterText: "one.primary",
-				insertText: ".primary(${1:color}) {\n\t$0\n}",
-				insertTextFormat: InsertTextFormat.Snippet,
-				kind: CompletionItemKind.Method,
-				label: "primary",
-				labelDetails: { detail: "($color: red) { }" },
-				sortText: undefined,
-				tags: [],
 			},
 		],
 	);
@@ -707,6 +801,7 @@ test("should suggest mixin with required parameter", async () => {
 	ls.configure({
 		completionSettings: {
 			suggestFromUseOnly: true,
+			suggestionStyle: "bracket",
 		},
 	});
 
@@ -734,28 +829,25 @@ test("should suggest mixin with required parameter", async () => {
 						"```scss\n@mixin primary($color)\n```\n____\nMixin declared in one.scss",
 				},
 				filterText: "one.primary",
-				insertText: ".primary(${1:color})",
-				insertTextFormat: InsertTextFormat.Snippet,
-				kind: CompletionItemKind.Method,
-				label: "primary",
-				labelDetails: { detail: "($color)" },
-				sortText: undefined,
-				tags: [],
-			},
-			{
-				documentation: {
-					kind: "markdown",
-					value:
-						"```scss\n@mixin primary($color)\n```\n____\nMixin declared in one.scss",
-				},
-				filterText: "one.primary",
-				insertText: ".primary(${1:color}) {\n\t$0\n}",
 				insertTextFormat: InsertTextFormat.Snippet,
 				kind: CompletionItemKind.Method,
 				label: "primary",
 				labelDetails: { detail: "($color) { }" },
 				sortText: undefined,
 				tags: [],
+				textEdit: {
+					newText: "one.primary(${1:color}) {\n\t$0\n}",
+					range: {
+						end: {
+							character: 18,
+							line: 1,
+						},
+						start: {
+							character: 14,
+							line: 1,
+						},
+					},
+				},
 			},
 		],
 	);
@@ -765,6 +857,7 @@ test("given both required and optional parameters should suggest two variants of
 	ls.configure({
 		completionSettings: {
 			suggestFromUseOnly: true,
+			suggestionStyle: "nobracket",
 		},
 	});
 
@@ -776,7 +869,7 @@ test("given both required and optional parameters should suggest two variants of
 	);
 	const two = fileSystemProvider.createDocument([
 		'@use "./one";',
-		".a { @include one.",
+		".a { @include one.; }",
 	]);
 
 	// emulate scanner of language service which adds workspace documents to the cache
@@ -794,13 +887,25 @@ test("given both required and optional parameters should suggest two variants of
 						"```scss\n@mixin primary($background, $color: red)\n```\n____\nMixin declared in one.scss",
 				},
 				filterText: "one.primary",
-				insertText: ".primary(${1:background})",
 				insertTextFormat: InsertTextFormat.Snippet,
 				kind: CompletionItemKind.Method,
 				label: "primary",
 				labelDetails: { detail: "($background)" },
 				sortText: undefined,
 				tags: [],
+				textEdit: {
+					newText: "one.primary(${1:background})",
+					range: {
+						end: {
+							character: 18,
+							line: 1,
+						},
+						start: {
+							character: 14,
+							line: 1,
+						},
+					},
+				},
 			},
 			{
 				documentation: {
@@ -809,43 +914,25 @@ test("given both required and optional parameters should suggest two variants of
 						"```scss\n@mixin primary($background, $color: red)\n```\n____\nMixin declared in one.scss",
 				},
 				filterText: "one.primary",
-				insertText: ".primary(${1:background}) {\n\t$0\n}",
-				insertTextFormat: InsertTextFormat.Snippet,
-				kind: CompletionItemKind.Method,
-				label: "primary",
-				labelDetails: { detail: "($background) { }" },
-				sortText: undefined,
-				tags: [],
-			},
-			{
-				documentation: {
-					kind: "markdown",
-					value:
-						"```scss\n@mixin primary($background, $color: red)\n```\n____\nMixin declared in one.scss",
-				},
-				filterText: "one.primary",
-				insertText: ".primary(${1:background}, ${2:color})",
 				insertTextFormat: InsertTextFormat.Snippet,
 				kind: CompletionItemKind.Method,
 				label: "primary",
 				labelDetails: { detail: "($background, $color: red)" },
 				sortText: undefined,
 				tags: [],
-			},
-			{
-				documentation: {
-					kind: "markdown",
-					value:
-						"```scss\n@mixin primary($background, $color: red)\n```\n____\nMixin declared in one.scss",
+				textEdit: {
+					newText: "one.primary(${1:background}, ${2:color})",
+					range: {
+						end: {
+							character: 18,
+							line: 1,
+						},
+						start: {
+							character: 14,
+							line: 1,
+						},
+					},
 				},
-				filterText: "one.primary",
-				insertText: ".primary(${1:background}, ${2:color}) {\n\t$0\n}",
-				insertTextFormat: InsertTextFormat.Snippet,
-				kind: CompletionItemKind.Method,
-				label: "primary",
-				labelDetails: { detail: "($background, $color: red) { }" },
-				sortText: undefined,
-				tags: [],
 			},
 		],
 	);
@@ -881,13 +968,25 @@ test("should suggest function with no parameter", async () => {
 					"```scss\n@function primary()\n```\n____\nFunction declared in one.scss",
 			},
 			filterText: "one.primary",
-			insertText: ".primary()",
 			insertTextFormat: InsertTextFormat.Snippet,
 			kind: CompletionItemKind.Function,
 			label: "primary",
 			labelDetails: { detail: "()" },
 			sortText: undefined,
 			tags: [],
+			textEdit: {
+				newText: "one.primary()",
+				range: {
+					end: {
+						character: 18,
+						line: 1,
+					},
+					start: {
+						character: 14,
+						line: 1,
+					},
+				},
+			},
 		},
 	);
 });
@@ -922,13 +1021,25 @@ test("should suggest function with optional parameter", async () => {
 					"```scss\n@function primary($color: red)\n```\n____\nFunction declared in one.scss",
 			},
 			filterText: "one.primary",
-			insertText: ".primary()",
 			insertTextFormat: InsertTextFormat.Snippet,
 			kind: CompletionItemKind.Function,
 			label: "primary",
 			labelDetails: { detail: "()" },
 			sortText: undefined,
 			tags: [],
+			textEdit: {
+				newText: "one.primary()",
+				range: {
+					end: {
+						character: 18,
+						line: 1,
+					},
+					start: {
+						character: 14,
+						line: 1,
+					},
+				},
+			},
 		},
 	);
 });
@@ -963,13 +1074,25 @@ test("should suggest function with required parameter", async () => {
 					"```scss\n@function primary($color)\n```\n____\nFunction declared in one.scss",
 			},
 			filterText: "one.primary",
-			insertText: ".primary(${1:color})",
 			insertTextFormat: InsertTextFormat.Snippet,
 			kind: CompletionItemKind.Function,
 			label: "primary",
 			labelDetails: { detail: "($color)" },
 			sortText: undefined,
 			tags: [],
+			textEdit: {
+				newText: "one.primary(${1:color})",
+				range: {
+					end: {
+						character: 18,
+						line: 1,
+					},
+					start: {
+						character: 14,
+						line: 1,
+					},
+				},
+			},
 		},
 	);
 });
@@ -1005,13 +1128,25 @@ test("given both required and optional parameters should suggest two variants of
 						"```scss\n@function primary($a, $b: 1)\n```\n____\nFunction declared in one.scss",
 				},
 				filterText: "one.primary",
-				insertText: ".primary(${1:a})",
 				insertTextFormat: InsertTextFormat.Snippet,
 				kind: CompletionItemKind.Function,
 				label: "primary",
 				labelDetails: { detail: "($a)" },
 				sortText: undefined,
 				tags: [],
+				textEdit: {
+					newText: "one.primary(${1:a})",
+					range: {
+						end: {
+							character: 18,
+							line: 1,
+						},
+						start: {
+							character: 14,
+							line: 1,
+						},
+					},
+				},
 			},
 			{
 				documentation: {
@@ -1020,13 +1155,25 @@ test("given both required and optional parameters should suggest two variants of
 						"```scss\n@function primary($a, $b: 1)\n```\n____\nFunction declared in one.scss",
 				},
 				filterText: "one.primary",
-				insertText: ".primary(${1:a}, ${2:b})",
 				insertTextFormat: InsertTextFormat.Snippet,
 				kind: CompletionItemKind.Function,
 				label: "primary",
 				labelDetails: { detail: "($a, $b: 1)" },
 				sortText: undefined,
 				tags: [],
+				textEdit: {
+					newText: "one.primary(${1:a}, ${2:b})",
+					range: {
+						end: {
+							character: 18,
+							line: 1,
+						},
+						start: {
+							character: 14,
+							line: 1,
+						},
+					},
+				},
 			},
 		],
 	);
@@ -1064,6 +1211,19 @@ test("should suggest all symbols as legacy @import may be in use", async () => {
 			label: "$primary",
 			sortText: undefined,
 			tags: [],
+			textEdit: {
+				newText: "$primary",
+				range: {
+					end: {
+						character: 12,
+						line: 0,
+					},
+					start: {
+						character: 12,
+						line: 0,
+					},
+				},
+			},
 		},
 	);
 });
@@ -1108,7 +1268,7 @@ test("should suggest symbol from a different document via @use with wildcard ali
 		},
 	);
 	const two = fileSystemProvider.createDocument(
-		['@use "./one" as *;', ".a { color: "],
+		['@use "./one" as *;', ".a { color: }"],
 		{
 			uri: "two.scss",
 		},
@@ -1129,6 +1289,19 @@ test("should suggest symbol from a different document via @use with wildcard ali
 			label: "$primary",
 			sortText: undefined,
 			tags: [],
+			textEdit: {
+				newText: "$primary",
+				range: {
+					end: {
+						character: 12,
+						line: 1,
+					},
+					start: {
+						character: 12,
+						line: 1,
+					},
+				},
+			},
 		},
 	);
 	assert.deepStrictEqual(
@@ -1140,7 +1313,6 @@ test("should suggest symbol from a different document via @use with wildcard ali
 					"```scss\n@function one()\n```\n____\nFunction declared in one.scss",
 			},
 			filterText: "one",
-			insertText: "one()",
 			insertTextFormat: InsertTextFormat.Snippet,
 			kind: CompletionItemKind.Function,
 			label: "one",
@@ -1149,6 +1321,19 @@ test("should suggest symbol from a different document via @use with wildcard ali
 			},
 			sortText: undefined,
 			tags: [],
+			textEdit: {
+				newText: "one()",
+				range: {
+					end: {
+						character: 12,
+						line: 1,
+					},
+					start: {
+						character: 12,
+						line: 1,
+					},
+				},
+			},
 		},
 	);
 });

--- a/packages/language-services/src/features/__tests__/do-complete-modules.test.ts
+++ b/packages/language-services/src/features/__tests__/do-complete-modules.test.ts
@@ -1060,8 +1060,6 @@ test("should suggest all symbols as legacy @import may be in use", async () => {
 		{
 			commitCharacters: [";", ","],
 			documentation: "limegreen\n____\nVariable declared in one.scss",
-			filterText: undefined,
-			insertText: undefined,
 			kind: CompletionItemKind.Color,
 			label: "$primary",
 			sortText: undefined,
@@ -1127,8 +1125,6 @@ test("should suggest symbol from a different document via @use with wildcard ali
 		{
 			commitCharacters: [";", ","],
 			documentation: "limegreen\n____\nVariable declared in one.scss",
-			filterText: undefined,
-			insertText: undefined,
 			kind: CompletionItemKind.Color,
 			label: "$primary",
 			sortText: undefined,

--- a/packages/language-services/src/features/__tests__/do-complete-placeholders.test.ts
+++ b/packages/language-services/src/features/__tests__/do-complete-placeholders.test.ts
@@ -29,9 +29,21 @@ test("when declaring a placeholder selector, suggest placeholders that have an @
 	const { items } = await ls.doComplete(two, Position.create(0, 1));
 	assert.deepStrictEqual(items[0], {
 		filterText: "main",
-		insertText: "main",
 		insertTextFormat: InsertTextFormat.PlainText,
 		kind: CompletionItemKind.Class,
 		label: "%main",
+		textEdit: {
+			newText: "%main",
+			range: {
+				end: {
+					character: 1,
+					line: 0,
+				},
+				start: {
+					character: 0,
+					line: 0,
+				},
+			},
+		},
 	});
 });

--- a/packages/language-services/src/features/__tests__/do-complete-sassdoc.test.ts
+++ b/packages/language-services/src/features/__tests__/do-complete-sassdoc.test.ts
@@ -285,7 +285,7 @@ ____
 Function declared in timing.scss`,
 				},
 				filterText: "t.timing",
-				insertText: '.timing(${1|"sonic","link","homer","snorlax"|})',
+
 				insertTextFormat: 2,
 				kind: 3,
 				label: "timing",
@@ -294,6 +294,19 @@ Function declared in timing.scss`,
 				},
 				sortText: undefined,
 				tags: [],
+				textEdit: {
+					newText: 't.timing(${1|"sonic","link","homer","snorlax"|})',
+					range: {
+						end: {
+							character: 28,
+							line: 2,
+						},
+						start: {
+							character: 22,
+							line: 2,
+						},
+					},
+				},
 			},
 		],
 	});

--- a/packages/language-services/src/features/do-diagnostics.ts
+++ b/packages/language-services/src/features/do-diagnostics.ts
@@ -66,9 +66,9 @@ export class DoDiagnostics extends LanguageFeature {
 
 	private async doUpstreamDiagnostics(document: TextDocument) {
 		if (
-			document.languageId === "vue" ||
-			document.languageId === "astro" ||
-			document.languageId === "svelte"
+			document.uri.endsWith(".vue") ||
+			document.uri.endsWith(".astro") ||
+			document.uri.endsWith(".svelte")
 		) {
 			return [];
 		}

--- a/packages/language-services/src/language-feature.ts
+++ b/packages/language-services/src/language-feature.ts
@@ -46,8 +46,6 @@ const defaultConfiguration: LanguageServiceConfiguration = {
 		suggestFunctionsInStringContextAfterSymbols: " (+-*%",
 		suggestionStyle: "all",
 		triggerPropertyValueCompletion: true,
-		afterModule: ".",
-		beforeVariable: "$",
 	},
 };
 

--- a/packages/language-services/src/language-feature.ts
+++ b/packages/language-services/src/language-feature.ts
@@ -20,6 +20,7 @@ import {
 	VariableDeclaration,
 	URI,
 	Utils,
+	ClientCapabilities,
 } from "./language-services-types";
 import { asDollarlessVariable } from "./utils/sass";
 
@@ -57,6 +58,7 @@ const defaultConfiguration: LanguageServiceConfiguration = {
 export abstract class LanguageFeature {
 	protected ls;
 	protected options;
+	protected clientCapabilities: ClientCapabilities;
 	protected configuration: LanguageServiceConfiguration = {};
 
 	private _internal: LanguageFeatureInternal;
@@ -72,6 +74,7 @@ export abstract class LanguageFeature {
 	) {
 		this.ls = ls;
 		this.options = options;
+		this.clientCapabilities = options.clientCapabilities;
 		this._internal = _internal;
 	}
 

--- a/packages/language-services/src/language-services-types.ts
+++ b/packages/language-services/src/language-services-types.ts
@@ -286,26 +286,13 @@ export interface ClientCapabilities {
 		completion?: {
 			completionItem?: {
 				documentationFormat?: MarkupKind[];
+				insertReplaceSupport?: boolean;
+				snippetSupport?: boolean;
 			};
 		};
 		hover?: {
 			contentFormat?: MarkupKind[];
 		};
-	};
-}
-
-export namespace ClientCapabilities {
-	export const LATEST: ClientCapabilities = {
-		textDocument: {
-			completion: {
-				completionItem: {
-					documentationFormat: [MarkupKind.Markdown, MarkupKind.PlainText],
-				},
-			},
-			hover: {
-				contentFormat: [MarkupKind.Markdown, MarkupKind.PlainText],
-			},
-		},
 	};
 }
 

--- a/packages/language-services/src/language-services-types.ts
+++ b/packages/language-services/src/language-services-types.ts
@@ -225,33 +225,6 @@ export interface LanguageServiceConfiguration {
 		 */
 		triggerPropertyValueCompletion?: boolean;
 		includePrefixDot?: boolean;
-		/**
-		 * If you end up with an extra `.` after accepting a suggestion, set this to the empty string.
-		 * If your module disappears, set it to "{module}" or "{module}." depending on your situation.
-		 *
-		 * @example
-		 * ```scss
-		 *  .foo {
-		 *    // set this setting to the empty string "" to fix this bug,
-		 *    // which varies depending on your editor's grammar for Sass.
-		 *    color: module..$variable;
-		 *  }
-		 * ```
-		 */
-		afterModule?: string;
-		/**
-		 * If you end up with an extra `&` after accepting a suggestion, set this to the empty string.
-		 *
-		 * @example
-		 * ```scss
-		 *  .foo {
-		 *    // set this setting to the empty string "" to fix this bug,
-		 *    // which varies depending on your editor's grammar for Sass.
-		 *    color: $$variable;
-		 *  }
-		 * ```
-		 */
-		beforeVariable?: string;
 	};
 	editorSettings?: EditorSettings;
 	workspaceRoot?: URI;

--- a/packages/language-services/src/utils/test-helpers.ts
+++ b/packages/language-services/src/utils/test-helpers.ts
@@ -126,7 +126,10 @@ export function getOptions(): LanguageServiceOptions & {
 		clientCapabilities: {
 			textDocument: {
 				completion: {
-					completionItem: { documentationFormat: ["markdown", "plaintext"] },
+					completionItem: {
+						snippetSupport: true,
+						documentationFormat: ["markdown", "plaintext"],
+					},
 				},
 				hover: {
 					contentFormat: ["markdown", "plaintext"],

--- a/vscode-extension/test/e2e/defaults-scss/completion.test.js
+++ b/vscode-extension/test/e2e/defaults-scss/completion.test.js
@@ -72,12 +72,11 @@ test("Offers namespaces completions including prefixes", async () => {
 	let expectedCompletions = [
 		{
 			label: "$var-var-variable",
-			insertText: '".$var-var-variable"',
-			filterText: '"ns.$var-var-variable"',
+			insertText: '"ns.$var-var-variable"',
 		},
 		{
 			label: "fun-fun-function",
-			insertText: '".fun-fun-function()"',
+			insertText: '"ns.fun-fun-function()"',
 		},
 	];
 
@@ -86,7 +85,7 @@ test("Offers namespaces completions including prefixes", async () => {
 	expectedCompletions = [
 		{
 			label: "mix-mix-mixin",
-			insertText: '".mix-mix-mixin"',
+			insertText: '"ns.mix-mix-mixin"',
 		},
 	];
 
@@ -116,12 +115,11 @@ test("Offers namespace completion inside string interpolation", async () => {
 	let expectedCompletions = [
 		{
 			label: "$var-var-variable",
-			insertText: '".$var-var-variable"',
-			filterText: '"ns.$var-var-variable"',
+			insertText: '"ns.$var-var-variable"',
 		},
 		{
 			label: "fun-fun-function",
-			insertText: '".fun-fun-function()"',
+			insertText: '"ns.fun-fun-function()"',
 		},
 	];
 
@@ -132,7 +130,7 @@ test("Offers completions for Sass built-ins", async () => {
 	let expectedCompletions = [
 		{
 			label: "floor",
-			insertText: '".floor(${1:number})"',
+			insertText: '"math.floor(${1:number})"',
 			filterText: '"math.floor"',
 		},
 	];
@@ -144,12 +142,12 @@ test("Offers namespace completion inside string interpolation with preceeding no
 	const expectedCompletions = [
 		{
 			label: "$var-var-variable",
-			insertText: '".$var-var-variable"',
+			insertText: '"ns.$var-var-variable"',
 			filterText: '"ns.$var-var-variable"',
 		},
 		{
 			label: "fun-fun-function",
-			insertText: '".fun-fun-function()"',
+			insertText: '"ns.fun-fun-function()"',
 		},
 	];
 
@@ -160,12 +158,11 @@ test("Offers namespace completion as part of return statement", async () => {
 	const expectedCompletions = [
 		{
 			label: "$var-var-variable",
-			insertText: '".$var-var-variable"',
-			filterText: '"ns.$var-var-variable"',
+			insertText: '"ns.$var-var-variable"',
 		},
 		{
 			label: "fun-fun-function",
-			insertText: '".fun-fun-function()"',
+			insertText: '"ns.fun-fun-function()"',
 		},
 	];
 

--- a/vscode-extension/test/web/suite/completion.test.js
+++ b/vscode-extension/test/web/suite/completion.test.js
@@ -19,12 +19,12 @@ test("for namespaces including prefixes", async () => {
 	let expectedCompletions = [
 		{
 			label: "$var-var-variable",
-			insertText: '".$var-var-variable"',
+			insertText: '"ns.$var-var-variable"',
 			filterText: '"ns.$var-var-variable"',
 		},
 		{
 			label: "fun-fun-function",
-			insertText: '".fun-fun-function()"',
+			insertText: '"ns.fun-fun-function()"',
 		},
 	];
 
@@ -33,7 +33,7 @@ test("for namespaces including prefixes", async () => {
 	expectedCompletions = [
 		{
 			label: "mix-mix-mixin",
-			insertText: '".mix-mix-mixin"',
+			insertText: '"ns.mix-mix-mixin"',
 		},
 	];
 
@@ -44,12 +44,12 @@ test("inside string interpolation", async () => {
 	const expectedCompletions = [
 		{
 			label: "$var-var-variable",
-			insertText: '".$var-var-variable"',
+			insertText: '"ns.$var-var-variable"',
 			filterText: '"ns.$var-var-variable"',
 		},
 		{
 			label: "fun-fun-function",
-			insertText: '".fun-fun-function()"',
+			insertText: '"ns.fun-fun-function()"',
 		},
 	];
 
@@ -60,7 +60,7 @@ test("for Sass built-ins", async () => {
 	const expectedCompletions = [
 		{
 			label: "floor",
-			insertText: '".floor(${1:number})"',
+			insertText: '"math.floor(${1:number})"',
 			filterText: '"math.floor"',
 		},
 	];
@@ -72,12 +72,12 @@ test("inside string interpolation with preceeding non-space character", async ()
 	const expectedCompletions = [
 		{
 			label: "$var-var-variable",
-			insertText: '".$var-var-variable"',
+			insertText: '"ns.$var-var-variable"',
 			filterText: '"ns.$var-var-variable"',
 		},
 		{
 			label: "fun-fun-function",
-			insertText: '".fun-fun-function()"',
+			insertText: '"ns.fun-fun-function()"',
 		},
 	];
 
@@ -88,12 +88,12 @@ test("as part of return statement", async () => {
 	const expectedCompletions = [
 		{
 			label: "$var-var-variable",
-			insertText: '".$var-var-variable"',
+			insertText: '"ns.$var-var-variable"',
 			filterText: '"ns.$var-var-variable"',
 		},
 		{
 			label: "fun-fun-function",
-			insertText: '".fun-fun-function()"',
+			insertText: '"ns.fun-fun-function()"',
 		},
 	];
 


### PR DESCRIPTION
The edge cases in different editors with regards to word boundaries has been too high (even for syntaxes in the same editor).

~~Since perhaps not all clients support it, adopting this without checking for clientCapabilities would be a breaking change. We keep the existing behavior for backwards compatibility.~~ Nevermind, I'm looking at it wrong. From 3.16 is the new InsertReplaceEdit. [`textEdit` is as old as the spec](https://github.com/Microsoft/language-server-protocol/blob/main/versions/protocol-1-x.md#completion-request).

TODO:

- [x] Add textEdit variant of all completion items.
- [x] Use clientCapabilities to decide whether or not snippets should be used (while we're at it)
- [x] Manual testing in VS Code
- [x] Manual testing in Sublime Text
- [x] Manual testing Helix
- [x] Update the automated tests with new assertions
- [x] Update documentation
- [ ] Call out now unused settings in release notes

Replaces #231 

For #230 