### PR TITLE
fix: no duplicate decorators if suggestAllFromOpenDocument is true

### DIFF
--- a/packages/language-services/src/features/find-colors.ts
+++ b/packages/language-services/src/features/find-colors.ts
@@ -73,10 +73,7 @@ export class FindColors extends LanguageFeature {
 			}),
 		);
 
-		if (
-			document.languageId === "sass" ||
-			this.configuration.completionSettings?.suggestAllFromOpenDocument
-		) {
+		if (document.languageId === "sass") {
 			const upstream = this.getUpstreamLanguageServer().findDocumentColors(
 				document,
 				stylesheet,


### PR DESCRIPTION
Fixes #233 