### PR TITLE
Multiline indented

### DIFF
--- a/packages/vscode-css-languageservice/src/parser/cssErrors.ts
+++ b/packages/vscode-css-languageservice/src/parser/cssErrors.ts
@@ -58,5 +58,4 @@ export const ParseError = {
 	IdentifierOrWildcardExpected: new CSSIssueType("css-idorwildcardexpected", l10n.t("identifier or wildcard expected")),
 	WildcardExpected: new CSSIssueType("css-wildcardexpected", l10n.t("wildcard expected")),
 	IdentifierOrVariableExpected: new CSSIssueType("css-idorvarexpected", l10n.t("identifier or variable expected")),
-	UnexpectedSemicolon: new CSSIssueType("css-nosemi", l10n.t("';' is not allowed in indented syntax")),
 };

--- a/packages/vscode-css-languageservice/src/parser/cssParser.ts
+++ b/packages/vscode-css-languageservice/src/parser/cssParser.ts
@@ -834,9 +834,7 @@ export class Parser {
 			return this.finish(node, ParseError.IdentifierExpected);
 		}
 
-		if (this.syntax === "indented" && this.accept(TokenType.SemiColon)) {
-			return this.finish(node, ParseError.UnexpectedSemicolon);
-		} else if (this.syntax !== "indented" && !this.accept(TokenType.SemiColon)) {
+		if (this.syntax !== "indented" && !this.accept(TokenType.SemiColon)) {
 			return this.finish(node, ParseError.SemiColonExpected);
 		}
 
@@ -914,9 +912,7 @@ export class Parser {
 			}
 		}
 
-		if (this.syntax === "indented" && this.accept(TokenType.SemiColon)) {
-			return this.finish(node, ParseError.UnexpectedSemicolon);
-		} else if (this.syntax !== "indented" && !this.accept(TokenType.SemiColon)) {
+		if (this.syntax !== "indented" && !this.accept(TokenType.SemiColon)) {
 			return this.finish(node, ParseError.SemiColonExpected);
 		}
 
@@ -1081,9 +1077,7 @@ export class Parser {
 		if ((!names || names.getChildren().length === 1) && (this.peek(TokenType.CurlyL) || this.peek(TokenType.Indent))) {
 			return this._parseBody(node, this._parseLayerDeclaration.bind(this, isNested));
 		}
-		if (this.syntax === "indented" && this.accept(TokenType.SemiColon)) {
-			return this.finish(node, ParseError.UnexpectedSemicolon);
-		} else if (this.syntax !== "indented" && !this.accept(TokenType.SemiColon)) {
+		if (this.syntax !== "indented" && !this.accept(TokenType.SemiColon)) {
 			return this.finish(node, ParseError.SemiColonExpected);
 		}
 		return this.finish(node);

--- a/packages/vscode-css-languageservice/src/parser/sassParser.ts
+++ b/packages/vscode-css-languageservice/src/parser/sassParser.ts
@@ -111,10 +111,6 @@ export class SassParser extends cssParser.Parser {
 		}
 
 		if (this.peek(TokenType.SemiColon)) {
-			if (this.syntax === "indented") {
-				return this.finish(node, ParseError.UnexpectedSemicolon);
-			}
-
 			node.semicolonPosition = this.token.offset; // not part of the declaration, but useful information for code assist
 		}
 
@@ -925,14 +921,8 @@ export class SassParser extends cssParser.Parser {
 			}
 		}
 
-		if (this.syntax === "indented") {
-			if (this.accept(TokenType.SemiColon)) {
-				return this.finish(node, ParseError.UnexpectedSemicolon);
-			}
-		} else {
-			if (!this.accept(TokenType.SemiColon) && !this.accept(TokenType.EOF)) {
-				return this.finish(node, ParseError.SemiColonExpected);
-			}
+		if (this.syntax !== "indented" && !this.accept(TokenType.SemiColon) && !this.accept(TokenType.EOF)) {
+			return this.finish(node, ParseError.SemiColonExpected);
 		}
 
 		return this.finish(node);
@@ -1019,14 +1009,8 @@ export class SassParser extends cssParser.Parser {
 			}
 		}
 
-		if (this.syntax === "indented") {
-			if (this.accept(TokenType.SemiColon)) {
-				return this.finish(node, ParseError.UnexpectedSemicolon);
-			}
-		} else {
-			if (!this.accept(TokenType.SemiColon) && !this.accept(TokenType.EOF)) {
-				return this.finish(node, ParseError.SemiColonExpected);
-			}
+		if (this.syntax !== "indented" && !this.accept(TokenType.SemiColon) && !this.accept(TokenType.EOF)) {
+			return this.finish(node, ParseError.SemiColonExpected);
 		}
 
 		return this.finish(node);

--- a/packages/vscode-css-languageservice/src/test/sass/parserIndented.test.ts
+++ b/packages/vscode-css-languageservice/src/test/sass/parserIndented.test.ts
@@ -18,7 +18,6 @@ suite("Sass - Parser", () => {
 	test("@charset", () => {
 		assertNode('@charset "demo"', parser, parser._parseStylesheet.bind(parser));
 		assertError("@charset", parser, parser._parseStylesheet.bind(parser), ParseError.IdentifierExpected);
-		assertError('@charset "demo";', parser, parser._parseStylesheet.bind(parser), ParseError.UnexpectedSemicolon);
 	});
 
 	test("newline before at-rule", () => {
@@ -3346,7 +3345,43 @@ body
 		);
 	});
 
-	test("flags semicolon as error in variable declaration", async () => {
-		assertError(`$font-size: 20px;`, parser, parser._parseStylesheet.bind(parser), ParseError.UnexpectedSemicolon);
+	test("allows semicolon to explicitly end statements", () => {
+		assertNode('@charset "demo";', parser, parser._parseStylesheet.bind(parser));
+		assertNode(`$font-size: 20px;`, parser, parser._parseStylesheet.bind(parser));
+	});
+
+	suite("multiline", () => {
+		test("where statements can't end", () => {
+			assertNode(
+				`
+@each $item in
+		1 2 3
+	.item-#{
+		$item
+	}
+		content: $item *
+				10
+	`,
+				parser,
+				parser._parseStylesheet.bind(parser),
+			);
+		});
+
+		test("with parentheses", () => {
+			assertNode(
+				`
+@font-face
+  font-family: "Leatherman"
+  src: (
+    local("Leatherman"),
+    url("leatherman-COLRv1.otf") format("opentype") tech(color-COLRv1),
+    url("leatherman-outline.otf") format("opentype"),
+    url("leatherman-outline.woff") format("woff")
+  )
+		`,
+				parser,
+				parser._parseStylesheet.bind(parser),
+			);
+		});
 	});
 });


### PR DESCRIPTION
Opening a draft for visibility. With Sass 1.84.0 the [indented syntax got a new behavior for newlines](https://github.com/sass/sass/blob/main/accepted/indented-syntax-improvements.md#line-breaks).

> line breaks only end statements when a statement can end, and in any other case, a line break is treated as non-meaningful white space.

The parser in Some Sass needs work to adapt to this change.

If you are eager to use this language feature, help would be very much appreciated. The PR adds two tests ([debuggable](https://wkillerud.github.io/some-sass/contributing/debugging-unit-tests.html)) that show some of the possibilities with this new behavior, but this affects pretty much the whole parser.

> In the indented syntax, authors can use a semicolon to explicitly end a statement. Subsequent lines in the same block still must have the same level of indentation. This means that the indented format won't support multiple statements on a single line, even if they are separated by a semicolon.

Solved in 1f893263c7b85a301a77aa27b30c3f4ddbf947e5