### PR TITLE
fix: handle newlines after charset in indented

### DIFF
--- a/packages/vscode-css-languageservice/src/parser/cssParser.ts
+++ b/packages/vscode-css-languageservice/src/parser/cssParser.ts
@@ -315,6 +315,12 @@ export class Parser {
 			// Parse statements only valid at the beginning of stylesheets.
 		}
 
+		if (this.syntax === "indented") {
+			while (this.accept(TokenType.Newline)) {
+				// allow empty statements after stylesheet start
+			}
+		}
+
 		let inRecovery = false;
 		do {
 			let hasMatch = false;

--- a/packages/vscode-css-languageservice/src/test/sass/parserIndented.test.ts
+++ b/packages/vscode-css-languageservice/src/test/sass/parserIndented.test.ts
@@ -21,6 +21,10 @@ suite("Sass - Parser", () => {
 		assertError('@charset "demo";', parser, parser._parseStylesheet.bind(parser), ParseError.UnexpectedSemicolon);
 	});
 
+	test("at-rule after @charset", () => {
+		assertNode('@charset "demo"\n\n@use "sass:list"', parser, parser._parseStylesheet.bind(parser));
+	});
+
 	test("newline before at-rule", () => {
 		assertNode(
 			`


### PR DESCRIPTION
Fixes a complaint from the parser about an unknown at-rule.

Fixes #316
