### PR TITLE
fix: indented comment syntax highlighting

### DIFF
--- a/vscode-extension/languages/sass.tmLanguage.json
+++ b/vscode-extension/languages/sass.tmLanguage.json
@@ -218,6 +218,9 @@
 					"include": "#comment_line"
 				},
 				{
+					"include": "#comment_end_of_line"
+				},
+				{
 					"include": "#comment_block"
 				}
 			]
@@ -313,6 +316,9 @@
 				},
 				{
 					"include": "#comment_line"
+				},
+				{
+					"include": "#comment_end_of_line"
 				}
 			]
 		},
@@ -548,6 +554,9 @@
 						},
 						{
 							"include": "#comment_line"
+						},
+						{
+							"include": "#comment_end_of_line"
 						},
 						{
 							"match": "\\b(only)\\b",
@@ -841,6 +850,9 @@
 					"include": "#comment_line"
 				},
 				{
+					"include": "#comment_end_of_line"
+				},
+				{
 					"include": "#comment_block"
 				},
 				{
@@ -946,13 +958,23 @@
 			"name": "comment.block.sass"
 		},
 		"comment_line": {
-			"begin": "//",
+			"begin": "^([ \\t]*)(//)",
+			"while": "^\\1(\\s|\\t)+.*$",
 			"beginCaptures": {
 				"0": {
 					"name": "punctuation.definition.comment.sass"
 				}
 			},
+			"name": "comment.line.sass"
+		},
+		"comment_end_of_line": {
+			"begin": "//",
 			"end": "\\n",
+			"captures": {
+				"0": {
+					"name": "punctuation.definition.comment.sass"
+				}
+			},
 			"name": "comment.line.sass"
 		},
 		"constant_default": {
@@ -1107,6 +1129,9 @@
 				},
 				{
 					"include": "#comment_line"
+				},
+				{
+					"include": "#comment_end_of_line"
 				}
 			]
 		},
@@ -1174,6 +1199,9 @@
 				},
 				{
 					"include": "#comment_line"
+				},
+				{
+					"include": "#comment_end_of_line"
 				},
 				{
 					"match": "\\b([\\w-]+)\\s*(:)",
@@ -1765,6 +1793,9 @@
 						},
 						{
 							"include": "#comment_line"
+						},
+						{
+							"include": "#comment_end_of_line"
 						},
 						{
 							"include": "#map"


### PR DESCRIPTION
Update indented grammar to handle indented comments.

Fixes #250

<img width="1892" height="1232" alt="Screenshot showing indented comments at different scopes, all highlighted as comments. Shows an end-of-line // comment as well to confirm that still works." src="https://github.com/user-attachments/assets/86bc88ef-4228-48e1-9da0-b3405c1e51e9" />

